### PR TITLE
Añadida lógica para actualizar el estado de las actividades en curso.

### DIFF
--- a/src/components/program-item.js
+++ b/src/components/program-item.js
@@ -5,9 +5,8 @@ import moment from 'moment';
 import 'moment/locale/es';
 import DrawAttentionView from './draw-attention-view';
 import { TOUCHABLE_UNDERLAY_COLOR } from '../styles/colors';
-import { getNow } from '../helpers/program-helpers';
 
-const ProgramItem = React.memo(({ navigation, show }) => {
+const ProgramItem = React.memo(({ navigation, show, nowDt }) => {
   const date = moment(show.date).format('DD MMM');
   const startTime = moment(parseInt(show.time[0])).format('HH:mm');
   const categoryIcon = iconsMap.get(show.participant_subcategory);
@@ -24,8 +23,7 @@ const ProgramItem = React.memo(({ navigation, show }) => {
 
   let icon = baseIcon;
 
-  const now = getNow();
-  const isLive = start <= now && now < end;
+  const isLive = start <= nowDt && nowDt < end;
 
   if (isLive) {
     icon = (

--- a/src/components/show-list.js
+++ b/src/components/show-list.js
@@ -6,9 +6,9 @@ import ProgramItem from './program-item';
 
 const ROW_HEIGHT = 80;
 
-const ShowList = ({ shows, flatListRef, navigation }) => {
+const ShowList = ({ shows, flatListRef, navigation, nowDt }) => {
   const extractKey = item => item.id + item.time[0];
-  const renderItem = ({ item }) => <ProgramItem navigation={navigation} show={item} />;
+  const renderItem = ({ item }) => <ProgramItem navigation={navigation} show={item} nowDt={nowDt} />;
 
   return (
     <SafeAreaView>

--- a/src/helpers/program-helpers.js
+++ b/src/helpers/program-helpers.js
@@ -146,3 +146,50 @@ export const programAdapter = program => {
     programItem.short_description = finalShortDescription;
   });
 };
+
+const TEN_MINUTES = 10 * 60 * 1000;
+
+export const findCurrentShowIndex = (shows, nowDt) => {
+  if (shows.length === 0) {
+    return -1;
+  }
+
+  let next = null;
+  let active = null;
+
+  for (let index = 0; index < shows.length; ++index) {
+    const show = shows[index];
+    const start = show.time[0];
+    const end = show.time[1];
+
+    if (start < nowDt) {
+      if (end > nowDt && start >= nowDt - TEN_MINUTES) {
+        // Prioridad 1: actividad en curso que ha comenzado hace menos de 10 minutos
+        return index;
+      } else if (active == null && end > nowDt) {
+        // Guardamos la primera actividad en curso por si no encontramos ninguna
+        // candidata mejor para devolver.
+        active = index;
+      }
+    } else {
+      if (start <= nowDt + TEN_MINUTES * 2) {
+        // Prioridad 2: actividad que comienza dentro de menos de 20 minutos
+        return index;
+      } else {
+        next = index;
+        break;
+      }
+    }
+  }
+
+  if (active != null) {
+    // Prioridad 3: actividad en curso que ha comenzado hace más de 10 minutos
+    return active;
+  } else if (next != null) {
+    // Prioridad 4: la siguiente actividad
+    return next;
+  } else {
+    // Si todas las actividades han pasado ya, devolvemos la primera actividad
+    return 0;
+  }
+};

--- a/tests/helpers/program-helpers.test.js
+++ b/tests/helpers/program-helpers.test.js
@@ -1,4 +1,4 @@
-import { programAdapter } from '../../src/helpers/program-helpers';
+import { programAdapter, findCurrentShowIndex } from '../../src/helpers/program-helpers';
 
 describe('programAdapter', () => {
   describe('cuando la short_description no incluye categorias', () => {
@@ -74,6 +74,197 @@ describe('programAdapter', () => {
           short_description: 'test description\n (conFusión, carrera de relevos, concurso de bofetadas )\n '
         }
       );
+    });
+  });
+});
+
+describe('findCurrentShowIndex', () => {
+  const toEpoch = (hhmm) => {
+    const parts = hhmm.split(':');
+    const baseDt = 1634374800;
+
+    const hourValue = parseInt(parts[0]) * 60 * 60;
+    const minuteValue = parseInt(parts[1]) * 60;
+
+    return (baseDt + hourValue + minuteValue) * 1000;
+  };
+
+  const makeShow = (name, start, end) => {
+    return {
+      short_description: name,
+      time: [
+        '' + toEpoch(start),
+        '' + toEpoch(end)
+      ]
+    };
+  }
+
+  describe('dada una lista de actividades vacía', () => {
+    test('cuando solicitamos el índice de la actividad en curso devuelve -1', () => {
+      const shows = [];
+      const nowDt = toEpoch("12:00");
+      expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(-1);
+    });
+  });
+
+  describe('dada una lista con una actividad que ha comenzado hace menos de 10 minutos', () => {
+    test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la primera actividad que ha comenzado hace menos de 10 minutos', () => {
+      const shows = [
+        makeShow("A", "09:00", "10:00"),
+        makeShow("B", "09:30", "12:00"),
+        makeShow("C", "09:37", "10:45")
+      ];
+
+      let nowDt = toEpoch("09:39");
+
+      // La segunda actividad ha comenzado hace 9 minutos.
+      // La tercera también ha comenzado, pero la función nos tiene que devolver la primera
+      // actividad que cumple con el requisito.
+      expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(1);
+
+      nowDt = toEpoch("09:42");
+
+      // Ahora la segunda actividad ha comenzado hace más de 10 minutos, así que
+      // la función nos tiene que devoler la tercera actividad.
+      expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(2);
+    });
+  });
+
+  describe('dada una lista con todas las actividades por comenzar', () => {
+    const shows = [
+      makeShow('A', "15:00", "16:00"),
+      makeShow('B', "15:30", "16:45"),
+      makeShow('C', "17:00", "21:00")
+    ];
+    
+    describe('y ninguna actividad que comience dentro de menos de 20 minutos', () => {
+      const nowDt = toEpoch("03:00");
+
+      test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la primera actividad', () => {
+        expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(0);
+      });
+    });
+
+    describe('y una actividad que comienza dentro de menos de 20 minutos', () => {
+      const nowDt = toEpoch("14:41");
+
+      test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la primera actividad', () => {
+        expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(0);
+      });
+    });
+  });
+
+  describe('dada una lista sin ninguna actividad en curso', () => {
+    const shows = [
+      makeShow('A', "08:00", "11:00"),
+      makeShow('B', "10:30", "13:00"),
+      makeShow('C', "12:00", "12:20"),
+      makeShow('D', "17:00", "17:35"),
+      makeShow('F', "17:00", "18:00")
+    ];
+
+    describe('y ninguna actividad que comience dentro de menos de 20 minutos', () => {
+      const nowDt = toEpoch("16:35");
+      
+      test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la próxima actividad', () => {
+        // Actividad D
+        expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(3);
+      });
+    });
+
+    describe('y una actividad que comienza dentro de menos de 20 minutos', () => {
+      const nowDt = toEpoch("16:43");
+      
+      test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la próxima actividad', () => {
+        // Actividad D
+        expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(3);
+      });
+    });
+  });
+
+  describe('dada una lista con una actividad que ha comenzado hace más de 10 minutos', () => {
+    describe('y ninguna actividad que haya comenzado hace menos de 10 minutos', () => {
+      const shows = [
+        makeShow('A', "10:00", "11:15"),
+        makeShow('B', "10:30", "13:00"),
+        makeShow('C', "12:00", "12:20"),
+        makeShow('D', "13:00", "14:00")
+      ];
+
+      describe('y ninguna actividad que comience dentro de menos de 20 minutos', () => {
+        test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la primera actividad en curso', () => {
+          let nowDt = toEpoch("11:39");
+          // Actividad B, porque C empieza dentro de 21 minutos
+          expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(1);
+
+          nowDt = toEpoch("11:10");
+
+          debugger;
+          // Actividad A. A las 11:10 A y B están ambas activas pero debería devolver la primera
+          const newIndex = findCurrentShowIndex(shows, nowDt);
+          expect(newIndex).toStrictEqual(0);
+        });
+      });
+      
+      describe('y una actividad que comienza dentro de menos de 20 minutos', () => {
+        const nowDt = toEpoch("11:41");
+        
+        test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la actividad que está a punto de comenzar', () => {
+          // Actividad C, que empieza dentro de 19 minutos
+          expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(2);
+        });
+      });
+    });
+  });
+
+  describe('dada una lista una actividad terminada que ha comenzado hace menos de 10 minutos', () => {
+    // Edge case de una microactividad de 5 minutos...
+    const shows = [
+      makeShow('A', "10:00", "11:00"),
+      makeShow('B', "11:30", "11:35"),
+      makeShow('C', "13:00", "13:30"),
+      makeShow('D', "13:00", "14:50")
+    ];
+    
+    describe('y ninguna actividad que comience dentro de menos de 20 minutos', () => {
+      const nowDt = toEpoch("11:36");
+      
+      test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la próxima actividad', () => {
+        // Actividad C
+        expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(2);
+      });
+    });
+  });
+
+  describe('dada una lista una actividad que comienza en ahora mismo', () => {
+    describe('y ninguna actividad que haya comenzado hace menos de 10 minutos', () => {
+      const shows = [
+        makeShow('A', "10:00", "11:00"),
+        makeShow('B', "11:30", "12:00"),
+        makeShow('C', "12:40", "13:30")
+      ];
+      
+      const nowDt = toEpoch("11:30");
+      
+      test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la pŕoxima actividad', () => {
+        // Actividad B
+        expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(1);
+      });
+    });
+
+    describe('y una actividad que ha comenzado hace menos de 10 minutos', () => {
+      const shows = [
+        makeShow('A', "11:25", "11:50"),
+        makeShow('B', "11:30", "12:00"),
+        makeShow('C', "12:40", "13:30")
+      ];
+      
+      const nowDt = toEpoch("11:30");
+      
+      test('cuando solicitamos el índice de la actividad en curso nos devuelve el índice de la actividad que ha comenzado hace menos de 10 minutos', () => {
+        // Actividad A
+        expect(findCurrentShowIndex(shows, nowDt)).toStrictEqual(0);
+      });
     });
   });
 });


### PR DESCRIPTION
Añadida lógica para actualizar el estado de las actividades en curso.

El estado de las actividades se actualiza cada 1 minuto, de manera que si
la vista de eventos queda estática durante varios minutos, las actividades
que han terminado y las que han comenzado actualizarán su estilo.

Añadida también lógica nueva para el botón "Ahora": si no encuentra
un evento que haya comenzado en los últimos 10 minutos, intentará
localizar el primero que empiece en los próximos 20 minutos, el primero
que esté activo, o si no hay ninguno activo, simplemente la siguiente
actividad.